### PR TITLE
Switched to using our own doxygen generation command

### DIFF
--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Doxygen generation
-        uses: mattnotmitt/doxygen-action@v1.9.8
+        run: doxygen
 
       - name: Prepare tagfile
         run: sudo mv output-doxygen/tag.xml "output-doxygen/html/${{ github.event.repository.name }}.tag.xml"

--- a/cpack.cmake
+++ b/cpack.cmake
@@ -1,7 +1,7 @@
 set(MAINTAINER_NAME "Noah Reeder <noahreederatc@gmail.com>")
 set(PROJECT_VERSION_MAJOR 0)
 set(PROJECT_VERSION_MINOR 3)
-set(PROJECT_VERSION_PATCH 3)
+set(PROJECT_VERSION_PATCH 4)
 
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Shared code for University of Manitoba Robotics Team's robotic arm"
         CACHE STRING "Package description for the package metadata"


### PR DESCRIPTION
https://github.com/UMRoboticsTeam/umrt-arm-firmware-lib/pull/17 still didn't fix doxygen because we were using the `mattnotmitt/doxygen-action@v1.9.8` action instead of calling doxygen ourself, and that action spawns a different docker container to use doxygen in.